### PR TITLE
Detach client

### DIFF
--- a/main.go
+++ b/main.go
@@ -299,9 +299,6 @@ func runStreamLoop(c net.Conn, pty *os.File, input io.Writer) {
 
 			return nil
 		},
-		ErrorHandler: func(err error) {
-			errorOut(&tperror.TPError{err.Error(), tperror.ErrCommand})
-		},
 	}
 
 	s.Loop()


### PR DESCRIPTION
This implements detach functionality similar to docker's with ^P^Q. Please feel free to test it out. I also fixed the issue with the server crashing on detach.

This way, you can now run a container with termproxy bootstrapped, and people can simultaneously connect to it with nobody running the server. This way, you can get N people sharing.

/cc @unclejack 